### PR TITLE
fixes 'keys' to return array, rather than string

### DIFF
--- a/commands/keys.js
+++ b/commands/keys.js
@@ -29,7 +29,7 @@ module.exports = function(client){
             if(_.isEmpty(data))
                 return fn();
 
-            return fn(null, data);
+            return fn(null, data.split(","));
         });
     }
 }


### PR DESCRIPTION
splits response on comma delimiter to return array rather than string